### PR TITLE
Extend backend with author endpoints and scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /theeasynews/node_modules
 /theeasynews/package-lock.json
+/server/node_modules
+/server/package-lock.json
+/server/data.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-## The Easy News
+# The Easy News
+
+This repository contains a small prototype for **The Easy News**, a web application that generates AI-written news articles.
+
+## Structure
+
+- `theeasynews/` – React frontend created with Create React App.
+- `server/` – Node.js/Express backend with a SQLite database.
+
+## Development
+
+1. Install dependencies for the frontend:
+   ```bash
+   cd theeasynews
+   npm install
+   ```
+
+2. Install backend dependencies:
+   ```bash
+   cd ../server
+   npm install
+   ```
+
+3. Start the backend server:
+   ```bash
+   node index.js
+   ```
+   The server listens on port `4000` by default.
+
+4. In another terminal, start the React development server:
+   ```bash
+   cd ../theeasynews
+   npm start
+   ```
+
+The frontend is served at `http://localhost:3000` and communicates with the backend API at `http://localhost:4000`.
+
+This prototype currently exposes basic endpoints for user registration, login, article creation, and saving articles. It uses a local SQLite database stored in `server/data.db`.
+
+### Scraping news
+
+To fetch headlines from the New York Times RSS feed into the local database run:
+
+```bash
+cd server
+npm run scrape
+```
+
+This inserts the latest headlines as articles that can later be expanded into AI-written pieces.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,118 @@
+const express = require('express');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+const Database = require('better-sqlite3');
+
+const db = new Database('data.db');
+
+db.exec(`CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  password TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS articles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  author TEXT NOT NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE IF NOT EXISTS saved_articles (
+  user_id INTEGER,
+  article_id INTEGER,
+  PRIMARY KEY(user_id, article_id)
+);
+CREATE TABLE IF NOT EXISTS authors (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT UNIQUE NOT NULL,
+  prompt TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_title ON articles(title);`);
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  const stmt = db.prepare('SELECT * FROM users WHERE username=? AND password=?');
+  const user = stmt.get(username, password);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  res.json({ message: 'Logged in', userId: user.id });
+});
+
+app.post('/api/register', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  try {
+    const stmt = db.prepare('INSERT INTO users (username, password) VALUES (?, ?)');
+    const info = stmt.run(username, password);
+    res.json({ userId: info.lastInsertRowid });
+  } catch (err) {
+    res.status(400).json({ error: 'User exists' });
+  }
+});
+
+app.get('/api/articles', (req, res) => {
+  const stmt = db.prepare('SELECT * FROM articles ORDER BY created_at DESC');
+  const articles = stmt.all();
+  res.json({ articles });
+});
+
+app.post('/api/articles', (req, res) => {
+  const { title, content, author } = req.body;
+  if (!title || !content || !author) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const stmt = db.prepare('INSERT INTO articles (title, content, author) VALUES (?, ?, ?)');
+  const info = stmt.run(title, content, author);
+  res.json({ articleId: info.lastInsertRowid });
+});
+
+app.post('/api/save', (req, res) => {
+  const { userId, articleId } = req.body;
+  if (!userId || !articleId) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const stmt = db.prepare('INSERT OR IGNORE INTO saved_articles (user_id, article_id) VALUES (?, ?)');
+  stmt.run(userId, articleId);
+  res.json({ message: 'Saved' });
+});
+
+app.get('/api/user/:userId/saved', (req, res) => {
+  const { userId } = req.params;
+  const stmt = db.prepare(
+    `SELECT articles.* FROM articles JOIN saved_articles ON articles.id = saved_articles.article_id WHERE saved_articles.user_id = ?`
+  );
+  const saved = stmt.all(userId);
+  res.json({ articles: saved });
+});
+
+app.post('/api/authors', (req, res) => {
+  const { name, prompt } = req.body;
+  if (!name || !prompt) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const stmt = db.prepare('INSERT INTO authors (name, prompt) VALUES (?, ?)');
+    const info = stmt.run(name, prompt);
+    res.json({ authorId: info.lastInsertRowid });
+  } catch (err) {
+    res.status(400).json({ error: 'Author exists' });
+  }
+});
+
+app.get('/api/authors', (req, res) => {
+  const authors = db.prepare('SELECT * FROM authors').all();
+  res.json({ authors });
+});
+
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => console.log('Server running on', PORT));

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "scrape": "node scrape.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "better-sqlite3": "^11.10.0",
+    "body-parser": "^2.2.0",
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "rss-parser": "^3.12.0"
+  }
+}

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -1,0 +1,18 @@
+const Parser = require('rss-parser');
+const Database = require('better-sqlite3');
+
+const parser = new Parser();
+const db = new Database('data.db');
+
+async function scrape() {
+  const feed = await parser.parseURL('https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml');
+  const insert = db.prepare('INSERT OR IGNORE INTO articles (title, content, author) VALUES (?, ?, ?)');
+  feed.items.slice(0, 10).forEach(item => {
+    insert.run(item.title, item.contentSnippet || item.content || '', 'RSS');
+  });
+  console.log('Scraped', feed.items.length, 'items');
+}
+
+scrape().catch(err => {
+  console.error('Scrape failed', err);
+});

--- a/theeasynews/src/App.test.js
+++ b/theeasynews/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Bluesky profile link', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/follow the easy news on bluesky/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- ignore SQLite database
- add authors database table and API endpoints
- create a simple RSS scraper script
- document how to run the scraper

## Testing
- `npm test --silent --prefix theeasynews -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c56e0354832cadc531754e09371f