### PR TITLE
Fix ESLint deps for API hooks

### DIFF
--- a/theeasynews/src/components/Articles.jsx
+++ b/theeasynews/src/components/Articles.jsx
@@ -10,7 +10,7 @@ const Articles = ({ userId }) => {
     fetch(`${API}/api/articles`)
       .then(res => res.json())
       .then(data => setArticles(data.articles || []));
-  }, []);
+  }, [API]);
 
   const save = async (articleId) => {
     await fetch(`${API}/api/save`, {

--- a/theeasynews/src/components/SavedArticles.jsx
+++ b/theeasynews/src/components/SavedArticles.jsx
@@ -7,7 +7,7 @@ const SavedArticles = ({ userId }) => {
     fetch(`${API}/api/user/${userId}/saved`)
       .then(res => res.json())
       .then(data => setArticles(data.articles || []));
-  }, [userId]);
+  }, [userId, API]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- clean up React `useEffect` deps to remove build warnings

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437c9f3d58832ca000ed3228253997