### PR TITLE
Fix database path error

### DIFF
--- a/scraper/index.js
+++ b/scraper/index.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
+const fs = require('fs');
 
 const API_KEY = process.env.NEWS_API_KEY;
 if (!API_KEY) {
@@ -9,6 +10,7 @@ if (!API_KEY) {
 }
 
 const DB_PATH = path.join(__dirname, '../server/data.db');
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
 const db = new sqlite3.Database(DB_PATH);
 
 async function fetchArticles() {

--- a/server/generate.js
+++ b/server/generate.js
@@ -1,7 +1,10 @@
 const { Configuration, OpenAIApi } = require('openai');
 const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
 
 const dbPath = process.env.DB_PATH || 'data.db';
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 const db = new Database(dbPath);
 
 const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });

--- a/server/index.js
+++ b/server/index.js
@@ -3,8 +3,11 @@ const cors = require('cors');
 const bodyParser = require('body-parser');
 const Database = require('better-sqlite3');
 const bcrypt = require('bcryptjs');
+const fs = require('fs');
+const path = require('path');
 
 const dbPath = process.env.DB_PATH || 'data.db';
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 const db = new Database(dbPath);
 
 db.exec(`CREATE TABLE IF NOT EXISTS users (

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -1,8 +1,11 @@
 const Parser = require('rss-parser');
 const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
 
 const parser = new Parser();
 const dbPath = process.env.DB_PATH || 'data.db';
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 const db = new Database(dbPath);
 
 async function scrape() {

--- a/server/seed-authors.js
+++ b/server/seed-authors.js
@@ -1,5 +1,8 @@
 const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
 const dbPath = process.env.DB_PATH || 'data.db';
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 const db = new Database(dbPath);
 
 const authors = [


### PR DESCRIPTION
## Summary
- create directory for configured `DB_PATH` before initializing the SQLite DB
- do this for the server, scraping scripts, and generator

## Testing
- `npm install` in `theeasynews`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684383627328832cb0934d36dd2d8b18