### PR TITLE
Enable Railway deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ React Router is used in the frontend tests so dependencies must be installed wit
    - `PORT` (if different from `4000`)
    - `DB_PATH` – path to the SQLite file (e.g. `/data/data.db` on a persistent volume)
    - `OPENAI_API_KEY` for article generation
-3. Railway will run `npm start` from the `server/` directory to launch the Express app.
+3. Railway runs `npm start` from the repository root. The root `package.json`
+   installs dependencies under `server/` and launches the Express app.
 
 ### Frontend on Netlify
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "theeasynews-root",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "theeasynews-root",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "theeasynews-root",
+  "private": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "postinstall": "npm install --prefix server",
+    "start": "npm start --prefix server"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root `package.json` so Railway can run the Express backend
- document the new start script in the deployment instructions

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68444ce83648832c9f0ba92c28dd24e8