### PR TITLE
Add hourly scraping and article generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,15 @@ expansion.
 
 ### Scraping news
 
-To fetch headlines from the New York Times RSS feed into the local database run:
+To fetch headlines from several major outlets into the local database run:
 
 ```bash
 cd server
 npm run scrape
 ```
 
-This inserts the latest headlines as articles that can later be expanded into AI-written pieces.
+This inserts the latest headlines from CNN, the Associated Press, Fox News and NPR. The
+articles can later be expanded into AI-written pieces.
 
 ### Seeding author personas
 
@@ -80,6 +81,17 @@ npm run generate
 
 Each run picks a random author persona and prompt from the `authors` table
 and updates scraped articles with AI-written content.
+
+### Automated generation
+
+To continuously scrape and generate content every hour run:
+
+```bash
+cd server
+npm run schedule
+```
+
+This job fetches new headlines and creates AI-written articles on a schedule.
 
 ### Running tests
 

--- a/server/generate.js
+++ b/server/generate.js
@@ -17,14 +17,23 @@ async function generateArticles() {
     console.error('No authors defined');
     return;
   }
+
+  const pickAuthor = (category) => {
+    const cat = (category || '').toLowerCase();
+    if (cat.includes('sport')) return authors.find(a => a.name.includes('Sports')) || authors[0];
+    if (cat.includes('politic')) return authors.find(a => a.name.includes('Politics')) || authors[0];
+    if (cat.includes('tech') || cat.includes('sci')) return authors.find(a => a.name.includes('AI')) || authors[0];
+    return authors[Math.floor(Math.random() * authors.length)];
+  };
+
   for (const article of articles) {
-    const author = authors[Math.floor(Math.random() * authors.length)];
+    const author = pickAuthor(article.category);
     const systemPrompt = `${author.persona}\n${author.prompt}`;
     const messages = [
       { role: 'system', content: systemPrompt },
       {
         role: 'user',
-        content: `Write a full news article based on the headline: "${article.title}"`,
+        content: `Write a full news article summarizing: "${article.title}"`,
       },
     ];
     try {
@@ -41,4 +50,8 @@ async function generateArticles() {
   }
 }
 
-generateArticles();
+module.exports = { generateArticles };
+
+if (require.main === module) {
+  generateArticles();
+}

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,8 @@ CREATE TABLE IF NOT EXISTS articles (
   title TEXT NOT NULL,
   content TEXT NOT NULL,
   author TEXT NOT NULL,
+  source TEXT,
+  category TEXT,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 CREATE TABLE IF NOT EXISTS saved_articles (
@@ -39,6 +41,15 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_articles_title ON articles(title);`);
 const authorCols = db.prepare('PRAGMA table_info(authors)').all();
 if (!authorCols.some(c => c.name === 'persona')) {
   db.exec('ALTER TABLE authors ADD COLUMN persona TEXT DEFAULT ""');
+}
+
+// Ensure newer columns exist on articles table
+const articleCols = db.prepare('PRAGMA table_info(articles)').all();
+if (!articleCols.some(c => c.name === 'source')) {
+  db.exec('ALTER TABLE articles ADD COLUMN source TEXT');
+}
+if (!articleCols.some(c => c.name === 'category')) {
+  db.exec('ALTER TABLE articles ADD COLUMN category TEXT');
 }
 
 const app = express();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "node-cron": "^3.0.2",
         "openai": "^4.18.0",
         "rss-parser": "^3.12.0"
       }
@@ -930,6 +931,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -1529,6 +1542,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "scrape": "node scrape.js",
     "generate": "node generate.js",
     "seed-authors": "node seed-authors.js",
-    "start": "node index.js"
+    "start": "node index.js",
+    "schedule": "node scheduler.js"
   },
   "keywords": [],
   "author": "",
@@ -21,6 +22,7 @@
     "express": "^5.1.0",
     "rss-parser": "^3.12.0",
     "openai": "^4.18.0",
-    "bcryptjs": "^2.4.3"
+    "bcryptjs": "^2.4.3",
+    "node-cron": "^3.0.2"
   }
 }

--- a/server/scheduler.js
+++ b/server/scheduler.js
@@ -1,0 +1,14 @@
+const cron = require('node-cron');
+const { scrapeFeeds } = require('./scrape');
+const { generateArticles } = require('./generate');
+
+async function runCycle() {
+  await scrapeFeeds();
+  await generateArticles();
+}
+
+cron.schedule('0 * * * *', () => {
+  runCycle().catch(err => console.error('cycle failed', err));
+});
+
+runCycle().catch(err => console.error('initial run failed', err));

--- a/server/scrape.js
+++ b/server/scrape.js
@@ -8,15 +8,37 @@ const dbPath = process.env.DB_PATH || 'data.db';
 fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 const db = new Database(dbPath);
 
-async function scrape() {
-  const feed = await parser.parseURL('https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml');
-  const insert = db.prepare('INSERT OR IGNORE INTO articles (title, content, author) VALUES (?, ?, ?)');
-  feed.items.slice(0, 10).forEach(item => {
-    insert.run(item.title, item.contentSnippet || item.content || '', 'RSS');
-  });
-  console.log('Scraped', feed.items.length, 'items');
+const feeds = [
+  { url: 'http://rss.cnn.com/rss/cnn_topstories.rss', source: 'cnn.com', category: 'top' },
+  { url: 'https://apnews.com/apf-topnews?output=rss', source: 'apnews.com', category: 'top' },
+  { url: 'http://feeds.foxnews.com/foxnews/latest', source: 'foxnews.com', category: 'top' },
+  { url: 'https://feeds.npr.org/1001/rss.xml', source: 'npr.org', category: 'top' }
+];
+
+async function scrapeFeeds() {
+  const insert = db.prepare(
+    'INSERT OR IGNORE INTO articles (title, content, author, source, category) VALUES (?, ?, ?, ?, ?)'
+  );
+
+  for (const feedInfo of feeds) {
+    try {
+      const feed = await parser.parseURL(feedInfo.url);
+      feed.items.slice(0, 10).forEach(item => {
+        const snippet = item.contentSnippet || item.content || '';
+        const category = (item.categories && item.categories[0]) || feedInfo.category;
+        insert.run(item.title, snippet, 'RSS', feedInfo.source, category);
+      });
+      console.log('Scraped', feedInfo.source, feed.items.length, 'items');
+    } catch (err) {
+      console.error('Failed to scrape', feedInfo.url, err.message);
+    }
+  }
 }
 
-scrape().catch(err => {
-  console.error('Scrape failed', err);
-});
+module.exports = { scrapeFeeds };
+
+if (require.main === module) {
+  scrapeFeeds().catch(err => {
+    console.error('Scrape failed', err);
+  });
+}


### PR DESCRIPTION
## Summary
- expand `scrape.js` to pull RSS feeds from CNN, AP, Fox News and NPR
- store source and category fields in the database
- choose authors by category when generating articles
- schedule scraping and generation every hour using `node-cron`
- document new commands in `README`

## Testing
- `npm install --prefix server`
- `npm test --prefix theeasynews -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684456ce4a88832cb175e483c69d3cec