### PR TITLE
Use env API URL in frontend

### DIFF
--- a/theeasynews/src/components/ArticleItem.jsx
+++ b/theeasynews/src/components/ArticleItem.jsx
@@ -3,10 +3,11 @@ import { FacebookShareButton, FacebookIcon, TwitterShareButton, TwitterIcon } fr
 
 const ArticleItem = ({ article, userId, onSaved }) => {
   const shareUrl = window.location.href;
+  const API = process.env.REACT_APP_API_URL;
 
   const save = () => {
     if (!userId) return;
-    fetch('http://localhost:5000/api/save', {
+    fetch(`${API}/api/save`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ userId, articleId: article.id })

--- a/theeasynews/src/components/ArticleList.jsx
+++ b/theeasynews/src/components/ArticleList.jsx
@@ -2,13 +2,14 @@ import React, { useEffect, useState } from 'react';
 import ArticleItem from './ArticleItem';
 const ArticleList = ({ userId }) => {
   const [articles, setArticles] = useState([]);
+  const API = process.env.REACT_APP_API_URL;
 
   useEffect(() => {
-    fetch('http://localhost:5000/api/articles')
+    fetch(`${API}/api/articles`)
       .then(res => res.json())
       .then(setArticles)
       .catch(() => setArticles([]));
-  }, []);
+  }, [API]);
 
   return (
     <div>

--- a/theeasynews/src/components/LoginForm.jsx
+++ b/theeasynews/src/components/LoginForm.jsx
@@ -4,10 +4,11 @@ const LoginForm = ({ onLogin }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
+  const API = process.env.REACT_APP_API_URL;
 
   const submit = e => {
     e.preventDefault();
-    fetch('http://localhost:5000/api/login', {
+    fetch(`${API}/api/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password })


### PR DESCRIPTION
## Summary
- reference API base URL via `REACT_APP_API_URL`
- update fetch calls in ArticleList, ArticleItem and LoginForm

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684496307c5c832cac7727d5cf222f5b